### PR TITLE
chore: add icon and color

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: "Sprocket Check"
 author: "St. Jude Cloud Rust Labs"
 description: "Check WDL documents for validity using Sprocket"
+branding:
+  icon: 'check-circle'
+  color: 'blue'
 inputs:
   lint:
     description: "Whether to lint the WDL document"


### PR DESCRIPTION
Apparently, best practices for GitHub Actions include an `icon` and a `color`. I've somewhat arbitrarily chosen this icon and color.

You can checkout the available colors and icons in the marketplace: https://github.com/marketplace?type=actions. Here is an action that has the same icon (though in white): https://github.com/marketplace/actions/super-linter.