### PR TITLE
feat: add support for validate-inputs subcomand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM rust:1.82
+FROM ghcr.io/stjude-rust-labs/sprocket:v0.10.1
 WORKDIR /app
 
 COPY . .
-
-RUN cargo install sprocket
 
 ENTRYPOINT ["sprocket"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Sprocket GitHub Action
 
-This action provides the functionality of the [Sprocket](https://github.com/stjude-rust-labs/sprocket) tool.
+This action provides select functionality of the [Sprocket](https://github.com/stjude-rust-labs/sprocket) command line tool for use in CI/CD pipelines.
 
 ## `check` | `lint`
 
@@ -64,7 +64,7 @@ A WDL document containing a task or workflow for which to check inputs.
 
 #### inputs_file
 
-A JSON format inputs file for the task or workflow
+A JSON format inputs file for the task or workflow.
 
 ### Example usage
 

--- a/README.md
+++ b/README.md
@@ -3,38 +3,77 @@
 
 # Sprocket GitHub Action
 
-This action uses [Sprocket](https://github.com/stjude-rust-labs/sprocket) to validate and optionally lint WDL documents.
+This action provides the functionality of the [Sprocket](https://github.com/stjude-rust-labs/sprocket) tool.
 
-## Inputs
+## `check` | `lint`
 
-### `lint`
+The `check` and `lint` subcommands perform static analysis on WDL documents. The `lint` command (or the `lint: true` option to `check`) additionally enables linting rules
+
+### Inputs
+
+#### `lint`
 
 **Optional** Whether to run linting in addition to validation. Boolean, valid choices: ["true", "false"]
 
-### `exclude-patterns`
+#### `exclude-patterns`
 
 **Optional** Comma separated list of patterns to exclude when searching for WDL files.
 
-### `deny-warnings`
+#### `deny-warnings`
 
 **Optional** If specified, Sprocket `check` will fail if any `warnings` are produced.
 
-### `deny-notes`
+#### `deny-notes`
 
 **Optional** If specified, Sprocket `check` will fail if any `notes` are produced.
 
-### `except`
+#### `except`
 
 **Optional** If specified, then the listed rules will be excepted from all `sprocket check` reports. Multiple rules can be specified as a comma-separated list, e.g. `CallInputSpacing,CommandSectionMixedIndentation`. Valid options can be found at: [analysis rules](https://github.com/stjude-rust-labs/wdl/blob/main/wdl-analysis/RULES.md) and [lint rules](https://github.com/stjude-rust-labs/wdl/blob/main/wdl-lint/RULES.md).
 
-## Example usage
+### Example usage
 
-```
+```yaml
 uses: stjude-rust-labs/sprocket-action@main
 with:
+    action: check
     lint: true
     exclude-patterns: template,test
     except: TrailingComma,ContainerValue
+```
+
+The action `lint` can be specified and is equivalent to specifying `action: check` and `lint: true`.
+
+```yaml
+uses: stjude-rust-labs/sprocket-action@main
+with:
+    action: lint
+    exclude-patterns: template,test
+    except: TrailingComma,ContainerValue
+```
+
+## `validate-inputs`
+
+Validates an input JSON against a task or workflow input schema.
+
+### Inputs
+
+#### wdl_file
+
+A WDL document containing a task or workflow for which to check inputs.
+
+#### inputs_file
+
+A JSON format inputs file for the task or workflow
+
+### Example usage
+
+```yaml
+uses: stjude-rust-labs/sprocket-action@main
+with:
+    action: validate-inputs
+    wdl_file: "tools/bwa.wdl"
+    inputs_file: "inputs/bwa.json"
 ```
 
 ## License and Legal

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Validates an input JSON against a task or workflow input schema.
 
 #### wdl_file
 
-A WDL document containing a task or workflow for which to check inputs.
+A comma-separated list of WDL documents containing a task or workflow for which to check inputs.
 
 #### inputs_file
 
-A JSON format inputs file for the task or workflow.
+A matching comma-separated list of JSON format inputs file for the task(s)/workflow(s). Ordering must match `wdl_file` as no checking will be performed.
 
 ### Example usage
 
@@ -74,6 +74,15 @@ with:
     action: validate-inputs
     wdl_file: "tools/bwa.wdl"
     inputs_file: "inputs/bwa.json"
+```
+
+Multiple files can be specified as well.
+```yaml
+uses: stjude-rust-labs/sprocket-action@main
+with:
+    action: validate-inputs
+    wdl_file: "tools/bwa.wdl,tools/star.wdl"
+    inputs_file: "inputs/bwa.json,inputs/star.wdl"
 ```
 
 ## License and Legal

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This action provides select functionality of the [Sprocket](https://github.com/s
 
 ## `check` | `lint`
 
-The `check` and `lint` subcommands perform static analysis on WDL documents. The `lint` command (or the `lint: true` option to `check`) additionally enables linting rules
+The `check` and `lint` subcommands perform static analysis on WDL documents. The `lint: true` option additionally enables linting rules. The `lint` subcommand is an alias for `check` with linting enabled.
 
 ### Inputs
 
 #### `lint`
 
-**Optional** Whether to run linting in addition to validation. Boolean, valid choices: ["true", "false"]
+**Optional** Whether to run linting in addition to validation. Boolean, valid choices: ["true", "false"].
 
 #### `exclude-patterns`
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A comma-separated list of WDL documents containing a task or workflow for which 
 
 #### inputs_files
 
-A matching comma-separated list of JSON format inputs file for the task(s)/workflow(s). Ordering must match `wdl_file` as no checking will be performed.
+A matching comma-separated list of JSON format inputs file for the task(s)/workflow(s). Ordering must match `wdl_files` as no checking will be performed.
 
 ### Example usage
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Validates an input JSON against a task or workflow input schema.
 
 ### Inputs
 
-#### wdl_file
+#### wdl_files
 
 A comma-separated list of WDL documents containing a task or workflow for which to check inputs.
 
-#### inputs_file
+#### inputs_files
 
 A matching comma-separated list of JSON format inputs file for the task(s)/workflow(s). Ordering must match `wdl_file` as no checking will be performed.
 
@@ -72,8 +72,8 @@ A matching comma-separated list of JSON format inputs file for the task(s)/workf
 uses: stjude-rust-labs/sprocket-action@main
 with:
     action: validate-inputs
-    wdl_file: "tools/bwa.wdl"
-    inputs_file: "inputs/bwa.json"
+    wdl_files: "tools/bwa.wdl"
+    inputs_files: "inputs/bwa.json"
 ```
 
 Multiple files can be specified as well.
@@ -81,8 +81,8 @@ Multiple files can be specified as well.
 uses: stjude-rust-labs/sprocket-action@main
 with:
     action: validate-inputs
-    wdl_file: "tools/bwa.wdl,tools/star.wdl"
-    inputs_file: "inputs/bwa.json,inputs/star.wdl"
+    wdl_files: "tools/bwa.wdl,tools/star.wdl"
+    inputs_files: "inputs/bwa.json,inputs/star.wdl"
 ```
 
 ## License and Legal

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: 'check'
   # Options for `check` and `lint` subcommands
   lint:
-    description: "Whether to lint the WDL document"
+    description: "Whether to lint WDL documents."
     required: false
     default: 'false'
   exclude-patterns:

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,12 @@ branding:
   icon: 'check-circle'
   color: 'blue'
 inputs:
+  # General options
+  action:
+    description: "Sprocket subcommand to run."
+    required: true
+    default: 'check'
+  # Options for `check` and `lint` subcommands
   lint:
     description: "Whether to lint the WDL document"
     required: false
@@ -25,6 +31,13 @@ inputs:
     description: 'Comma separated list of rules to exclude from Sprocket check.'
     required: false
     default: ''
+  # Options for `validate-inputs` subcommand
+  wdl_file:
+    description: "Path to the WDL document for which to validate inputs."
+    required: false
+  inputs_file:
+    description: "Path to the JSON file containing inputs to validate."
+    required: false
 outputs:
   status:
     description: "The status of the check"

--- a/action.yml
+++ b/action.yml
@@ -32,10 +32,10 @@ inputs:
     required: false
     default: ''
   # Options for `validate-inputs` subcommand
-  wdl_file:
+  wdl_files:
     description: "Path to the WDL document for which to validate inputs."
     required: false
-  inputs_file:
+  inputs_files:
     description: "Path to the JSON file containing inputs to validate."
     required: false
 outputs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,8 @@ echo "exceptions: $INPUT_EXCEPT"
 echo "warnings: $INPUT_WARNINGS"
 echo "notes: $INPUT_NOTES"
 echo "patterns: $INPUT_PATTERNS"
-echo "wdl_file: $INPUT_WDL_FILE"
-echo "inputs_file: $INPUT_INPUTS_FILE"
+echo "wdl_file: $INPUT_WDL_FILES"
+echo "inputs_file: $INPUT_INPUTS_FILES"
 
 if [ $INPUT_ACTION = "check" ] || [ $INPUT_ACTION = "lint" ]; then
     echo "Checking WDL files."
@@ -79,9 +79,10 @@ elif [ $INPUT_ACTION = "validate-inputs" ]; then
 
     EXITCODE=0
 
-    # Split the input variables on either "," or " " to get the list of files
-    IFS=',' read -r -a input_files <<< "$INPUT_INPUTS_FILE"
-    IFS=',' read -r -a wdl_files <<< "$INPUT_WDL_FILE"
+    # Split the input variables on "," to get the list of files.
+    # IFS treats each character as a delimiter.
+    IFS=',' read -r -a input_files <<< "$INPUT_INPUTS_FILES"
+    IFS=',' read -r -a wdl_files <<< "$INPUT_WDL_FILES"
 
     # Note: this depends on the user to get the pairing correct upfront.
     for index in "${!input_files[@]}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,70 +3,98 @@
 set -euo pipefail
 
 echo "===configuration==="
+echo "action: $INPUT_ACTION"
 echo "lint: $INPUT_LINT"
 echo "exceptions: $INPUT_EXCEPT"
 echo "warnings: $INPUT_WARNINGS"
 echo "notes: $INPUT_NOTES"
 echo "patterns: $INPUT_PATTERNS"
+echo "wdl_file: $INPUT_WDL_FILE"
+echo "inputs_file: $INPUT_INPUTS_FILE"
 
-lint=""
-exceptions=""
-
-if [ $INPUT_LINT = "true" ]; then
-    lint="--lint"
-fi
-
-if [ -n "$INPUT_EXCEPT" ]; then
-    echo "Excepted rule(s) provided."
-    for exception in $(echo $INPUT_EXCEPT | sed 's/,/ /')
-    do
-        exceptions="$exceptions --except $exception"
-    done
-fi
-
-warnings=""
-
-if [ ${INPUT_WARNINGS} = "true" ]; then
-    warnings="--deny-warnings"
-fi
-
-notes=""
-
-if [ ${INPUT_NOTES} = "true" ]; then
-    notes="--deny-notes"
-fi
-
-exclusions=${INPUT_PATTERNS}
-
-if [ -n "$exclusions" ]; then
-    echo "Exclusions provided. Writing to .sprocket.yml."
-    echo -n "" > .sprocket.yml
-    for exclusion in $(echo $exclusions | sed 's/,/ /g')
-    do
-        echo "$exclusion" >> .sprocket.yml
-    done
-    
-    echo "  [***] Exclusions [***]"
-    cat .sprocket.yml
-fi
-
-EXITCODE=0
-
-echo "Checking WDL files using \`sprocket check\`."
-for file in $(find $GITHUB_WORKSPACE -name "*.wdl")
-do
-    if [ -e ".sprocket.yml" ]
-    then
-        if [ $(echo $file | grep -cvf .sprocket.yml) -eq 0 ]
-        then
-            echo "  [***] Excluding $file [***]"
-            continue
-        fi
+if [ $INPUT_ACTION = "check" ] || [ $INPUT_ACTION = "lint" ]; then
+    echo "Checking WDL files."
+    lint=""
+    exceptions=""
+    if [ $INPUT_LINT = "true" ] || [ $INPUT_ACTION = "lint" ]; then
+        lint="--lint"
     fi
-    echo "  [***] $file [***]"
-    echo "sprocket check --single-document $lint $warnings $notes $exceptions $file"
-    sprocket check --single-document $lint $warnings $notes $exceptions $file || EXITCODE=$(($? || EXITCODE))
-done
 
-echo "status=$EXITCODE" >> $GITHUB_OUTPUT
-exit $EXITCODE
+    if [ -n "$INPUT_EXCEPT" ]; then
+        echo "Excepted rule(s) provided."
+        for exception in $(echo $INPUT_EXCEPT | sed 's/,/ /')
+        do
+            exceptions="$exceptions --except $exception"
+        done
+    fi
+
+    warnings=""
+
+    if [ ${INPUT_WARNINGS} = "true" ]; then
+        warnings="--deny-warnings"
+    fi
+
+    notes=""
+
+    if [ ${INPUT_NOTES} = "true" ]; then
+        notes="--deny-notes"
+    fi
+
+    exclusions=${INPUT_PATTERNS}
+
+    if [ -n "$exclusions" ]; then
+        echo "Exclusions provided. Writing to .sprocket.yml."
+        echo -n "" > .sprocket.yml
+        for exclusion in $(echo $exclusions | sed 's/,/ /g')
+        do
+            echo "$exclusion" >> .sprocket.yml
+        done
+        
+        echo "  [***] Exclusions [***]"
+        cat .sprocket.yml
+    fi
+
+    EXITCODE=0
+
+    echo "Checking WDL files using \`sprocket check\`."
+    for file in $(find $GITHUB_WORKSPACE -name "*.wdl")
+    do
+        if [ -e ".sprocket.yml" ]
+        then
+            if [ $(echo $file | grep -cvf .sprocket.yml) -eq 0 ]
+            then
+                echo "  [***] Excluding $file [***]"
+                continue
+            fi
+        fi
+        echo "  [***] $file [***]"
+        echo "sprocket check --single-document $lint $warnings $notes $exceptions $file"
+        sprocket check --single-document $lint $warnings $notes $exceptions $file || EXITCODE=$(($? || EXITCODE))
+    done
+
+    echo "status=$EXITCODE" >> $GITHUB_OUTPUT
+    exit $EXITCODE
+elif [ $INPUT_ACTION = "validate-inputs" ]; then
+    echo "Validating inputs"
+
+    EXITCODE=0
+
+    echo "sprocket validate-inputs --inputs $INPUT_INPUTS_FILE $INPUT_WDL_FILE"
+    sprocket validate-inputs --inputs $INPUT_INPUTS_FILE $INPUT_WDL_FILE || EXITCODE=$(($? || EXITCODE))
+
+    echo "status=$EXITCODE" >> $GITHUB_OUTPUT
+    exit $EXITCODE
+elif [ $INPUT_ACTION = "format" ]; then
+    echo "Format is currently unsupported."
+    exit 1
+elif [ $INPUT_ACTION = "analyzer" ]; then
+    echo "Action `analyzer` is unsupported."
+    exit 1
+elif [ $INPUT_ACTION = "explain" ]; then
+    echo "Action `explain` is unsupported."
+    exit 1
+else
+    echo "Invalid action. Exiting."
+    exit 1
+fi
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,8 @@ echo "exceptions: $INPUT_EXCEPT"
 echo "warnings: $INPUT_WARNINGS"
 echo "notes: $INPUT_NOTES"
 echo "patterns: $INPUT_PATTERNS"
-echo "wdl_file: $INPUT_WDL_FILES"
-echo "inputs_file: $INPUT_INPUTS_FILES"
+echo "wdl_files: $INPUT_WDL_FILES"
+echo "inputs_files: $INPUT_INPUTS_FILES"
 
 if [ $INPUT_ACTION = "check" ] || [ $INPUT_ACTION = "lint" ]; then
     echo "Checking WDL files."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,14 +80,14 @@ elif [ $INPUT_ACTION = "validate-inputs" ]; then
     EXITCODE=0
 
     # Split the input variables on either "," or " " to get the list of files
-    IFS=', ' read -r -a input_files <<< "$INPUT_INPUTS_FILE"
-    IFS=', ' read -r -a wdl_files <<< "$INPUT_WDL_FILE"
+    IFS=',' read -r -a input_files <<< "$INPUT_INPUTS_FILE"
+    IFS=',' read -r -a wdl_files <<< "$INPUT_WDL_FILE"
 
     # Note: this depends on the user to get the pairing correct upfront.
     for index in "${!input_files[@]}"
     do
         echo "sprocket validate-inputs --inputs ${input_files[index]} ${wdl_files[index]}"
-        sprocket validate-inputs --inputs ${input_files[index]} ${wdl_files[index]} || EXITCODE=$(($? || EXITCODE))
+        sprocket validate-inputs --inputs "${input_files[index]}" "${wdl_files[index]}" || EXITCODE=$(($? || EXITCODE))
     done
 
     echo "status=$EXITCODE" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,8 +79,14 @@ elif [ $INPUT_ACTION = "validate-inputs" ]; then
 
     EXITCODE=0
 
-    echo "sprocket validate-inputs --inputs $INPUT_INPUTS_FILE $INPUT_WDL_FILE"
-    sprocket validate-inputs --inputs $INPUT_INPUTS_FILE $INPUT_WDL_FILE || EXITCODE=$(($? || EXITCODE))
+    IFS=', ' read -r -a input_files <<< "$INPUT_INPUTS_FILE"
+    IFS=', ' read -r -a wdl_files <<< "$INPUT_WDL_FILE"
+
+    for index in "${!input_files[@]}"
+    do
+        echo "sprocket validate-inputs --inputs ${input_files[index]} ${wdl_files[index]}"
+        sprocket validate-inputs --inputs ${input_files[index]} ${wdl_files[index]} || EXITCODE=$(($? || EXITCODE))
+    done
 
     echo "status=$EXITCODE" >> $GITHUB_OUTPUT
     exit $EXITCODE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,9 +79,11 @@ elif [ $INPUT_ACTION = "validate-inputs" ]; then
 
     EXITCODE=0
 
+    # Split the input variables on either "," or " " to get the list of files
     IFS=', ' read -r -a input_files <<< "$INPUT_INPUTS_FILE"
     IFS=', ' read -r -a wdl_files <<< "$INPUT_WDL_FILE"
 
+    # Note: this depends on the user to get the pairing correct upfront.
     for index in "${!input_files[@]}"
     do
         echo "sprocket validate-inputs --inputs ${input_files[index]} ${wdl_files[index]}"


### PR DESCRIPTION
Reworks `action.yml` and `entrypoint.sh` to enable support for additional subcommand of `sprocket`.
Adds initial support for the `validate-inputs` subcommand.