### PR TITLE
chore: bump sprocket version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/stjude-rust-labs/sprocket:v0.12.2
+FROM ghcr.io/stjude-rust-labs/sprocket:v0.14.0
 WORKDIR /app
 
 COPY . .


### PR DESCRIPTION
Bump sprocket version to latest (0.14.0) to get updated lint rules