### PR TITLE
chore: update `Dockerfile` to include bash for entrypoint script.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ghcr.io/stjude-rust-labs/sprocket:v0.15.0
 WORKDIR /app
 
+RUN apk add --update bash
+
 COPY . .
 
 ENTRYPOINT ["sprocket"]


### PR DESCRIPTION
This PR adds `bash` to the image now that it is based on Alpine and the base image does not include it.